### PR TITLE
previous git clone link give permission error

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To use this addon, you must install a script on your computer. The script will b
 - Linux 
 
 ### Installation
-1. `git clone git@github.com:Frewacom/Pywalfox.git`
+1. `git clone https://github.com/Frewacom/Pywalfox.git`
 2. `cd Pywalfox`
 3. `bash setup.sh`
 


### PR DESCRIPTION
guess it's this https://github.com/Frewacom/Pywalfox.git instead of git@github.com:Frewacom/Pywalfox.git,
```
[ ~ ] git clone git@github.com:Frewacom/Pywalfox.git
Cloning into 'Pywalfox'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```