### PR TITLE
Fix exit code in daemon

### DIFF
--- a/daemon/pywalfox.py
+++ b/daemon/pywalfox.py
@@ -39,7 +39,7 @@ if len(sys.argv) == 2:
 
         # Send a message to the UNIX-socket, telling it to send the new colorscheme to the addon
         client.sendMessage('update')
-        sys.exit(1)
+        sys.exit(0)
 
 # Send the version of daemon to the addon
 def sendVersion():


### PR DESCRIPTION
Hi,

Thanks a lot for pywalfox, I love it!
I use a script to automatically update Firefox theme after a wallpaper change and noticed your daemon return the wrong exit code.
I received an exit code of `1` (Which means an error as occurred) while my Firefox theme was correctly updated. This PR simply change the exit code from `1` to `0` (Success).