### PR TITLE
feat: add feature to inject CSS variables into every website

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -80,6 +80,7 @@
         "theme",
         "storage",
         "tabs",
-        "alarms"
+        "alarms",
+        "<all_urls>"
     ]
 }

--- a/src/background/generators.ts
+++ b/src/background/generators.ts
@@ -59,6 +59,7 @@ export function generateColorscheme(
     extension: generateExtensionTheme(palette),
     duckduckgo: generateDuckduckgoTheme(palette, template.duckduckgo),
     darkreader: generateDarkreaderScheme(palette, mode),
+    website: generateWebsiteCSS(palette),
   };
 }
 
@@ -121,6 +122,17 @@ export function generateExtensionTheme(palette: IPalette) {
   return `${EXTENSION_THEME_SELCTOR}{${variables}}`;
 }
 
+export function generateWebsiteCSS(palette: IPalette) {
+  let variables: string = '';
+
+  PALETTE_TEMPLATE_DATA.forEach(({ target, cssVariable }) => {
+    const variableName = cssVariable.replace('--', '--pywalfox-');
+    variables += `${variableName}:${palette[target]};`;
+  });
+
+  return `:root{${variables}}`;
+}
+
 export function generateDarkreaderScheme({ background, text }: IPalette, mode: ITemplateThemeMode) {
   if (mode === ThemeModes.Dark) {
     return {
@@ -164,4 +176,5 @@ export default {
   pywalPalette: generatePywalPalette,
   duckduckgo: generateDuckduckgoTheme,
   darkreader: generateDarkreaderScheme,
+  website: generateWebsiteCSS,
 };

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -125,6 +125,7 @@ export interface IColorscheme {
   extension: IExtensionTheme;
   duckduckgo: IDuckDuckGoTheme;
   darkreader: IDarkreaderScheme;
+  website: string;
 }
 
 export interface IThemeTemplate {


### PR DESCRIPTION
Allows the user to style the websites using `userContent.css` for example (or websites could use these variables if someone wants to be fancy, thus the "pywalfox" prefix to prevent collisions).

Eg. like requested in #151 I think?

Not perfect but works for me :D

Adds these variables into every tab:
<img width="330" height="155" alt="image" src="https://github.com/user-attachments/assets/bdad45f3-0136-45e2-bb4f-b40d7da26c51" />
